### PR TITLE
makedb.sh: fail if a command exits non-zero

### DIFF
--- a/database/builder/makedb.sh
+++ b/database/builder/makedb.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 g++ builder.cpp -o builder -lshp
 
 rm -rf out naturalearth timezone db.zip


### PR DESCRIPTION
In particular this better handles the case where the `g++` command
fails (e.g. due to not having shapelib installed). The script should
not continue if that command fails.