### PR TITLE
Add a Makefile and more documentation for the demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+demo: Makefile demo.c library/zonedetect.c
+	gcc -o demo demo.c -Wall -Ilibrary library/zonedetect.c -lm

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a C library that allows you to find an area a point belongs to using a database file. A typical example would be looking up the country or timezone given a latitude and longitude. The timezone database also contains the country information.
 
-The API should be self-explanatory from zonedetect.h. A small demo is included (demo.c)
+The API should be self-explanatory from zonedetect.h. A small demo is included (demo.c). You can build the demo with `make demo` and run it like this: `./demo timezone21.bin 35.0715 -82.5216`.
 
 The databases are obtained from [here](https://github.com/evansiroky/timezone-boundary-builder) and converted to the format used by this library.
 


### PR DESCRIPTION
This adds a simple `make demo` target that builds the demo with
`gcc`. The readme is also updated to mention the make target and give
an example of how to run it. The example should make clearer what is
to be passed in as the `dbname` parameter; initially I tried `db.zip`
and passing in the `out_v1` directory path before realizing that each
of the database files is separate and that the full path should be
given.