### PR TITLE
properly check error for mmap

### DIFF
--- a/library/zonedetect.c
+++ b/library/zonedetect.c
@@ -880,7 +880,7 @@ ZoneDetect *ZDOpenDatabase(const char *path)
         lseek(library->fd, 0, SEEK_SET);
 
         library->mapping = mmap(NULL, (size_t)library->length, PROT_READ, MAP_PRIVATE | MAP_FILE, library->fd, 0);
-        if(!library->mapping) {
+        if(library->mapping == MAP_FAILED) {
             zdError(ZD_E_DB_MMAP, errno);
             goto fail;
         }


### PR DESCRIPTION
The existing if-check for an error from mmap will never be true, as mmap never returns zero. On errors mmap returns MAP_FAILED (or -1), so properly check for this.

Originally reported to geeqie, which copied over this code:
https://github.com/BestImageViewer/geeqie/pull/771