### PR TITLE
Fix broken download of ne.zip

### DIFF
--- a/database/builder/makedb.sh
+++ b/database/builder/makedb.sh
@@ -11,7 +11,7 @@ mkdir -p naturalearth
 mkdir -p timezone
 
 (
-echo https://naciscdn.org/naturalearth/10m/cultural/ne_10m_admin_0_countries_lakes.zip -o /dev/null -O naturalearth/ne.zip
+echo https://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_admin_0_countries_lakes.zip -o /dev/null -O naturalearth/ne.zip
 echo https://github.com/evansiroky/timezone-boundary-builder/releases/download/2020d/timezones-with-oceans.shapefile.zip -o /dev/null -O timezone/tz.zip
 ) | xargs -n5 -P2 wget
 


### PR DESCRIPTION
Partially reverts 6a1d2a6165cd0e43d2f413e3e047570caaa364b4. naciscdn.org
is down and judging from other projects' github issues this seems to be
common.