### PR TITLE
build: fix builder compilation on macOS

### DIFF
--- a/database/builder/builder.cpp
+++ b/database/builder/builder.cpp
@@ -49,7 +49,7 @@ void errorFatal(std::string what)
     exit(1);
 }
 
-void assert(bool mustBeTrue, std::string what){
+void assert_(bool mustBeTrue, std::string what){
     if(!mustBeTrue){
         errorFatal(what);
     }
@@ -87,13 +87,13 @@ int encodeVariableLength(std::vector<uint8_t>& output, int64_t valueIn, bool han
 }
 
 uint64_t encodePointTo64(int64_t lat, int64_t lon){
-    assert(lat || lon, "Tried to encode 0,0. This is not allowed");
+    assert_(lat || lon, "Tried to encode 0,0. This is not allowed");
 
     uint64_t latu=encodeSignedToUnsigned(lat);
     uint64_t lonu=encodeSignedToUnsigned(lon);
 
-    assert(latu < (uint64_t)1<<32, "Unsigned lat overflow");
-    assert(lonu < (uint64_t)1<<32, "Unsigned lat overflow");
+    assert_(latu < (uint64_t)1<<32, "Unsigned lat overflow");
+    assert_(lonu < (uint64_t)1<<32, "Unsigned lat overflow");
 
     uint64_t point = 0;
     for(uint8_t i=31; i<=31; i--){

--- a/database/builder/makedb.sh
+++ b/database/builder/makedb.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-g++ builder.cpp -o builder -lshp
+g++ builder.cpp --std=c++11 -o builder -lshp
 
 rm -rf out naturalearth timezone db.zip
 mkdir -p out


### PR DESCRIPTION
- assert() is already defined, so rename this assert() to assert_()
- std::tie is a c++11 feature; on macOS, g++ maps to clang and clang
    defaults to c++old, so explicitly declare the c++ version
- these changes should be benign on other platforms
  (e.g., Linux .. tested on ubuntu 20.04)