### PR TITLE
add API function to free memory dynamically allocated by function ZDHelperSimpleLookupString

### DIFF
--- a/library/zonedetect.c
+++ b/library/zonedetect.c
@@ -1249,3 +1249,8 @@ done:
     ZDFreeResults(result);
     return output;
 }
+
+void ZDHelperSimpleLookupStringFree(char* str)
+{
+    free(str);
+}

--- a/library/zonedetect.h
+++ b/library/zonedetect.h
@@ -83,6 +83,7 @@ ZD_EXPORT const char *ZDGetErrorString(int errZD);
 ZD_EXPORT float* ZDPolygonToList(const ZoneDetect *library, uint32_t polygonId, size_t* length);
 
 ZD_EXPORT char* ZDHelperSimpleLookupString(const ZoneDetect* library, float lat, float lon);
+ZD_EXPORT void ZDHelperSimpleLookupStringFree(char* str);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
On windows, zonedetect is built as a dll. The function ZDHelperSimpleLookup returns a string which is allocated on the heap. Because it is allocated on the heap in the dll, it is difficult to free this memory from the calling program, as the dll uses its own heap. So to avoid memory leaks in the calling program, the API should also provide a function to free this memory. This is what this change does.