### PR TITLE
replaces strcat by strcat_s to remove compiler error when using ms compiler

### DIFF
--- a/library/zonedetect.c
+++ b/library/zonedetect.c
@@ -1240,7 +1240,11 @@ char* ZDHelperSimpleLookupString(const ZoneDetect* library, float lat, float lon
         output[0] = 0;
         for(i=0; i<sizeof(strings)/sizeof(char*); i++) {
             if(strings[i]) {
+#if defined(_MSC_VER)
+                strcat_s(output + strlen(output),length-strlen(output), strings[i]);
+#else
                 strcat(output + strlen(output), strings[i]);
+#endif
             }
         }
     }

--- a/library/zonedetect.c
+++ b/library/zonedetect.c
@@ -1241,7 +1241,7 @@ char* ZDHelperSimpleLookupString(const ZoneDetect* library, float lat, float lon
         for(i=0; i<sizeof(strings)/sizeof(char*); i++) {
             if(strings[i]) {
 #if defined(_MSC_VER)
-                strcat_s(output + strlen(output),length-strlen(output), strings[i]);
+                strcat_s(output + strlen(output), length-strlen(output), strings[i]);
 #else
                 strcat(output + strlen(output), strings[i]);
 #endif


### PR DESCRIPTION
strcat is depreciated and causes compiler error when building on windows. strcat_s should now be used instead.