### PR TITLE
Add stddef.h for size_t in header file

### DIFF
--- a/library/zonedetect.h
+++ b/library/zonedetect.h
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifndef INCL_ZONEDETECT_H_


### PR DESCRIPTION
Got an error that size_t was not defined. I am no expert, but I suppose this is the way to fix it.

Probably not an issue in most cases, but I ran into this, so someone else might and then they will not have to think about it. I assume folks usually will have this defined as a happy coincidence before including the header.

Thanks for the library, I am enjoying it a lot. :+1: 